### PR TITLE
Link PyPI and GitHub to each other

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,3 +110,9 @@ Python compatibility
 
 RPly is tested and known to work under Python 2.6, 2.7, 3.1, and 3.2. It is
 also valid RPython for PyPy checkouts from ``6c642ae7a0ea`` onwards.
+
+Links
+-----
+
+* `Source code and issue tracker <https://github.com/alex/rply/>`_
+* `PyPI releases <https://pypi.python.org/pypi/rply>`_


### PR DESCRIPTION
Hi. I was on the PyPI page, wanted to look at the source, but didn’t find a link. Here is one.

At most it will appear on with the next release. I don’t know an easy way to update the PyPI metadata without making a new release; is there one?
