### PR TITLE
Add the line and column numbers to the lexemes' SourcePositions

### DIFF
--- a/rply/lexer.py
+++ b/rply/lexer.py
@@ -16,6 +16,20 @@ class LexerStream(object):
         self.lexer = lexer
         self.s = s
         self.idx = 0
+        self.linebreaks = [-1] + [i for i, letter in enumerate(s) if letter == '\n']
+
+    def source_position(self, position):
+        lineno = 0
+        broken = False
+        for lineno, linebreak in enumerate(self.linebreaks):
+            if position < linebreak:
+                broken = True
+                break
+
+        if not broken:
+            lineno += 1
+
+        return SourcePosition(position, lineno, (position - self.linebreaks[lineno-1]))
 
     def next(self):
         if self.idx >= len(self.s):
@@ -28,8 +42,7 @@ class LexerStream(object):
         for rule in self.lexer.rules:
             match = rule.matches(self.s, self.idx)
             if match:
-                # TODO: lineno and colno
-                source_pos = SourcePosition(match.start, -1, -1)
+                source_pos = self.source_position(match.start)
                 token = Token(rule.name, self.s[match.start:match.end], source_pos)
                 self.idx = match.end
                 return token

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -44,3 +44,37 @@ class TestLexer(object):
         assert t.source_pos.idx == 4
         t = stream.next()
         assert t is None
+
+    def test_position(self):
+        lg = LexerGenerator()
+        lg.add("NUMBER", r"\d+")
+        lg.add("PLUS", r"\+")
+        lg.ignore(r"\s+")
+
+        l = lg.build()
+
+        stream = l.lex("2 + 3")
+        t = stream.next()
+        assert t.source_pos.lineno == 1
+        assert t.source_pos.colno == 1
+        t = stream.next()
+        assert t.source_pos.lineno == 1
+        assert t.source_pos.colno == 3
+        t = stream.next()
+        assert t.source_pos.lineno == 1
+        assert t.source_pos.colno == 5
+        t = stream.next()
+        assert t is None
+
+        stream = l.lex("2 +\n    37")
+        t = stream.next()
+        assert t.source_pos.lineno == 1
+        assert t.source_pos.colno == 1
+        t = stream.next()
+        assert t.source_pos.lineno == 1
+        assert t.source_pos.colno == 3
+        t = stream.next()
+        assert t.source_pos.lineno == 2
+        assert t.source_pos.colno == 5
+        t = stream.next()
+        assert t is None


### PR DESCRIPTION
Hi,

I'm trying to rewrite the https://github.com/paultag/hy parser using rply. To do so keeping the compatibility, I need the line/column numbers on the lexemes.

I saw the TODO in the code, so I took a stab at this.

I'm not sure I like how I get the linebreaks at the time the LexerStream is created, but I'm not sure there is another way.

Enjoy!
