### PR TITLE
Fix typo in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - pip install pytest
     - wget https://bitbucket.org/pypy/pypy/get/default.tar.bz2 -O `pwd`/../pypy.tar.bz2
     - tar -xf `pwd`/../pypy.tar.bz2 -C `pwd`/../
-script: PYTHONPATH=$PYTONPATH:`python -c "import glob; import os; print os.path.abspath(glob.glob('../pypy-pypy*')[0])"` py.test
+script: PYTHONPATH=$PYTHONPATH:`python -c "import glob; import os; print os.path.abspath(glob.glob('../pypy-pypy*')[0])"` py.test
 notifications:
     email: false
 


### PR DESCRIPTION
I found this typo while I was unashamedly copying your Travis-CI file. I don't think it was making a difference because `$PYTHONPATH` (and certainly `$PYTONPATH`) are probably unset anyway. But I figured I'd fix it just the same.

RPLY and Topaz are great projects, by the way. I've learned a lot about RPython from both of them!
