### PR TITLE
Unify error handling, add expected tokens to context

### DIFF
--- a/docs/users-guide/parsers.rst
+++ b/docs/users-guide/parsers.rst
@@ -162,11 +162,15 @@ error handler:
 .. code:: python
 
     @pg.error
-    def error_handler(token):
-        raise ValueError("Ran into a %s where it was't expected" % token.gettokentype())
+    def error_handler(token, expected, state):
+        exp = ', '.join(sorted(expected))
+        msg = 'Ran into %s where it was expecting any of %s' % (token, exp)
+        raise ValueError(msg)
 
 The `token` passed to the error handler will be the token the parser errored
-on.
+on, whereas the set of `expected` values indicates which tokens _would_
+have been considered valid.  The `state` argument will be whatever state
+you kept while parsing (see next section for details), or `None` otherwise.
 
 
 Maintaining State

--- a/rply/parser.py
+++ b/rply/parser.py
@@ -52,10 +52,8 @@ class LRParser(object):
             else:
                 # TODO: actual error handling here
                 if self.error_handler is not None:
-                    if state is None:
-                        self.error_handler(lookahead)
-                    else:
-                        self.error_handler(state, lookahead)
+                    expected = self.lr_table.lr_action[current_state].keys()
+                    self.error_handler(lookahead, expected, state)
                     raise AssertionError("For now, error_handler must raise.")
                 else:
                     raise ParsingError(None, lookahead.getsourcepos())


### PR DESCRIPTION
This does two things:
1. Change error handler invocation to include a set of expected tokens. This is really useful to create error message to end users;
2. It unifies error handling by always calling the error handler with 3 arguments, in an order that makes sense: `token`, `expected`, `state`.  This means the order, and existence/absense of arguments does not depend on whether or not the parser has been initialized with a state or not.  The state is always included, even if it's `None`.

I realize this is a backward-incompatible change, but it definitely is a lot cleaner, I think. Let me know if you think this should be dealt with differently.

Example:

``` python
@pg.error
def error_handler(token, expected, state):
    exp = ', '.join(sorted(expected))
    msg = 'Ran into %s where it was expecting any of %s' % (token, exp)
    raise ValueError(msg)
```
