### PR TITLE
Add __version__ attribute

### DIFF
--- a/rply/__init__.py
+++ b/rply/__init__.py
@@ -3,6 +3,8 @@ from rply.lexergenerator import LexerGenerator
 from rply.parsergenerator import ParserGenerator
 from rply.token import Token
 
+__version__ = '0.7.4'
+
 __all__ = [
     "LexerGenerator", "ParserGenerator", "ParsingError", "Token"
 ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="rply",
     description="A pure Python Lex/Yacc that works with RPython",
     long_description=readme,
-    # duplicated in docs/conf.py
+    # duplicated in docs/conf.py and rply/__init__.py
     version="0.7.4",
     author="Alex Gaynor",
     author_email="alex.gaynor@gmail.com",


### PR DESCRIPTION
I'd like to make [i18nspector](https://github.com/jwilk/i18nspector)'s `--version` print versions of libraries it uses.
But there's currently no obvious way to get rply's version, other than maybe querying `pkg_resources` (eww).

So here's a patch to add the `__version__` attribute.