### PR TITLE
README: Capitalize "Python"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ RPLY
 .. image:: https://secure.travis-ci.org/alex/rply.png
     :target: https://travis-ci.org/alex/rply
 
-Welcome to RPLY! A pure python parser generator, that also works with RPython.
+Welcome to RPLY! A pure Python parser generator, that also works with RPython.
 It is a more-or-less direct port of David Beazley's awesome PLY, with a new
 public API, and RPython support.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 RPLY
 ====
 
-Welcome to RPLY! A pure python parser generator, that also works with RPython.
+Welcome to RPLY! A pure Python parser generator, that also works with RPython.
 It is a more-or-less direct port of David Beazley's awesome PLY, with a new
 public API, and RPython support.
 


### PR DESCRIPTION
The pedant in me was slightly bothered that it was “pure python” in one paragraph but “pure Python” in another.
So I standardized on the latter spelling.