### PR TITLE
Make `import rply` faster under coverage

### DIFF
--- a/rply/lexergenerator.py
+++ b/rply/lexergenerator.py
@@ -2,6 +2,14 @@ import re
 
 try:
     import rpython
+    from rpython.rlib.objectmodel import we_are_translated
+except ImportError:
+    rpython = None
+
+    def we_are_translated():
+        return False
+
+if we_are_translated():
     from rpython.annotator import model
     from rpython.annotator.bookkeeper import getbookkeeper
     from rpython.rlib.objectmodel import instantiate, hlinvoke
@@ -14,8 +22,6 @@ try:
     from rpython.rtyper.lltypesystem.rstr import STR, string_repr
     from rpython.rtyper.rmodel import Repr
     from rpython.tool.pairtype import pairtype
-except ImportError:
-    rpython = None
 
 from rply.lexer import Lexer
 
@@ -104,7 +110,7 @@ class LexerGenerator(object):
         """
         return Lexer(self.rules, self.ignore_rules)
 
-if rpython:
+if we_are_translated():
     class RuleEntry(ExtRegistryEntry):
         _type_ = Rule
 

--- a/tests/test_ztranslation.py
+++ b/tests/test_ztranslation.py
@@ -2,8 +2,20 @@ import py
 
 try:
     from rpython.rtyper.test.test_llinterp import interpret
+    import rpython.rlib.objectmodel
 except ImportError:
     py.test.skip("Needs RPython to be on the PYTHONPATH")
+
+try:
+    reload
+except NameError:
+    from importlib import reload
+
+old = rpython.rlib.objectmodel.we_are_translated
+rpython.rlib.objectmodel.we_are_translated = lambda: True
+import rply
+reload(rply.lexergenerator)
+rpython.rlib.objectmodel.we_are_translated = old
 
 from rply import LexerGenerator, ParserGenerator, Token
 from rply.errors import ParserGeneratorWarning


### PR DESCRIPTION
Importing rply under coverage.py is very slow because of the work done
when the rpython libraries are imported. This patch causes the classes
needed for translation to be set up only when rply needs to be
translated.

The monkeypatching in the test is pretty ugly but the module needs to get reloaded since we_are_translated() is only checked on import.