### PR TITLE
Fix compatibility with pytest 3.x

### DIFF
--- a/tests/test_ztranslation.py
+++ b/tests/test_ztranslation.py
@@ -3,7 +3,7 @@ import py
 try:
     from rpython.rtyper.test.test_llinterp import interpret
 except ImportError:
-    py.test.skip("Needs RPython to be on the PYTHONPATH")
+    pytestmark = py.test.mark.skip("Needs RPython to be on the PYTHONPATH")
 
 from rply import LexerGenerator, ParserGenerator, Token
 from rply.errors import ParserGeneratorWarning


### PR DESCRIPTION
```
==================================== ERRORS ====================================
_________________ ERROR collecting tests/test_ztranslation.py __________________
Using pytest.skip outside of a test is not allowed. If you are trying to decorate a test function, use the @pytest.mark.skip or @pytest.mark.skipif decorators instead.
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
=========================== 1 error in 0.17 seconds ============================
```