### PR TITLE
Make LexerGenerator docstring raw

### DIFF
--- a/rply/lexergenerator.py
+++ b/rply/lexergenerator.py
@@ -42,7 +42,7 @@ class Match(object):
 
 
 class LexerGenerator(object):
-    """
+    r"""
     A LexerGenerator represents a set of rules that match pieces of text that
     should either be turned into tokens or ignored by the lexer.
 


### PR DESCRIPTION
Fixes `DeprecationWarning: invalid escape sequence \d` with Python 3.6.