### PR TITLE
Create temporary cache file in cache directory

### DIFF
--- a/rply/parsergenerator.py
+++ b/rply/parsergenerator.py
@@ -193,7 +193,7 @@ class ParserGenerator(object):
                 if not os.path.exists(cache_dir):
                     os.makedirs(cache_dir, mode=0o0700)
 
-                with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
+                with tempfile.NamedTemporaryFile(dir=cache_dir, delete=False, mode="w") as f:
                     json.dump(self.serialize_table(table), f)
                 os.rename(f.name, cache_file)
 


### PR DESCRIPTION
Fixes:
```
OSError: [Errno 18] Invalid cross-device link
```
if `/tmp` and the cache directory are on different filesystems.