### PR TITLE
fix deprecation warning

### DIFF
--- a/rply/utils.py
+++ b/rply/utils.py
@@ -1,5 +1,9 @@
 import sys
-from collections import MutableMapping
+
+if sys.version_info > (3, 0):
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 
 class IdentityDict(MutableMapping):


### PR DESCRIPTION
When running with python 3.7 I get the following deprecation warning due to the import from `collections`:

```
/usr/local/lib/python3.7/site-packages/rply/utils.py:2
  /usr/local/lib/python3.7/site-packages/rply/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping
```