### PR TITLE
Fix version check for MutableMapping import

### DIFF
--- a/rply/utils.py
+++ b/rply/utils.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info > (3, 0):
+if sys.version_info >= (3, 3):
     from collections.abc import MutableMapping
 else:
     from collections import MutableMapping


### PR DESCRIPTION
Abstract base classes were moved from `collections` to `collections.abc` only in Python 3.3.