### PR TITLE
Adjust to rsre_core API change in lexergenerator.py

### DIFF
--- a/rply/lexergenerator.py
+++ b/rply/lexergenerator.py
@@ -33,9 +33,10 @@ class Rule(object):
             return Match(*m.span(0)) if m is not None else None
         else:
             assert pos >= 0
-            ctx = rsre_core.StrMatchContext(s, pos, len(s), self.flags)
-
-            matched = rsre_core.match_context(ctx, self._pattern)
+            ctx = rsre_core.StrMatchContext(self._pattern, s, pos, len(s), self.flags)
+#            ctx = rsre_core.StrMatchContext(s, pos, len(s), self.flags)
+            matched = rsre_core.match_context(ctx)
+#            matched = rsre_core.match_context(ctx, self._pattern)
             if matched:
                 return Match(ctx.match_start, ctx.match_end)
             else:


### PR DESCRIPTION
I was having an issue when trying to iterate over a LexerStream, where RPython was throwing a horrendous error as rsre_core.StrMatchContext wasn't getting enough arguments to __init__, and match_context was getting one too many arguments. A very simply change was made and my problem was solved.