### PR TITLE
Correct line and column number in source position when raising LexingError

### DIFF
--- a/rply/lexer.py
+++ b/rply/lexer.py
@@ -18,6 +18,7 @@ class LexerStream(object):
         self.idx = 0
 
         self._lineno = 1
+        self._colno = 1
 
     def __iter__(self):
         return self
@@ -47,14 +48,15 @@ class LexerStream(object):
             match = rule.matches(self.s, self.idx)
             if match:
                 lineno = self._lineno
-                colno = self._update_pos(match)
-                source_pos = SourcePosition(match.start, lineno, colno)
+                self._colno = self._update_pos(match)
+                source_pos = SourcePosition(match.start, lineno, self._colno)
                 token = Token(
                     rule.name, self.s[match.start:match.end], source_pos
                 )
                 return token
         else:
-            raise LexingError(None, SourcePosition(self.idx, -1, -1))
+            raise LexingError(None, SourcePosition(
+                self.idx, self._lineno, self._colno))
 
     def __next__(self):
         return self.next()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -150,3 +150,30 @@ class TestLexer(object):
             stream.next()
 
         assert 'SourcePosition(' in repr(excinfo.value)
+
+    def test_error_line_number(self):
+        lg = LexerGenerator()
+        lg.add("NEW_LINE", r"\n")
+        l = lg.build()
+
+        stream = l.lex("\nfail")
+        stream.next()
+        with raises(LexingError) as excinfo:
+            stream.next()
+
+        assert excinfo.value.source_pos.lineno == 2
+
+    def test_error_column_number(self):
+        lg = LexerGenerator()
+        lg.add("NUMBER", r"\d+")
+        lg.add("PLUS", r"\+")
+        l = lg.build()
+        stream = l.lex("1+2+fail")
+        stream.next()
+        stream.next()
+        stream.next()
+        stream.next()
+        with raises(LexingError) as excinfo:
+            stream.next()
+
+        assert excinfo.value.source_pos.colno == 4


### PR DESCRIPTION
When lexer is unable to find matching token, `LexingError` raises. This error contains source position for further debugging, but in current implementation it only points valid index (character number), while the line and colum numbers equal `-1`.

This PR fixes this issue by tracking column number in `next()` method of `LexerStream` and providing both `self._lineno` and `self._colno` to `SourcePosition` in `LexingError`.
